### PR TITLE
Fix sndcpy apk not found error

### DIFF
--- a/sndcpy
+++ b/sndcpy
@@ -2,7 +2,9 @@
 set -e
 ADB=${ADB:-adb}
 VLC=${VLC:-vlc}
-SNDCPY_APK=${SNDCPY_APK:-sndcpy.apk}
+SNDCPY_SCRIPT=$(realpath $0)
+SNDCPY_PATH=$(dirname $SNDCPY_SCRIPT)
+SNDCPY_APK=${SNDCPY_APK:-$SNDCPY_PATH/sndcpy.apk}
 SNDCPY_PORT=${SNDCPY_PORT:-28200}
 
 serial=

--- a/sndcpy.bat
+++ b/sndcpy.bat
@@ -1,7 +1,7 @@
 @echo off
 if not defined ADB set ADB=adb
 if not defined VLC set VLC="C:\Program Files\VideoLAN\VLC\vlc.exe"
-if not defined SNDCPY_APK set SNDCPY_APK=sndcpy.apk
+if not defined SNDCPY_APK set SNDCPY_APK=%~dp0\sndcpy.apk
 if not defined SNDCPY_PORT set SNDCPY_PORT=28200
 
 if not "%1"=="" (


### PR DESCRIPTION
Created this PR to fix iss in issue:
https://github.com/rom1v/sndcpy/issues/80

This should fix apk not found errors in both Windows and Linux when not running the script directly in its own directory.