### PR TITLE
Check automatically when the permission is granted

### DIFF
--- a/sndcpy
+++ b/sndcpy
@@ -24,6 +24,17 @@ fi
 
 "$ADB" $serial forward tcp:$SNDCPY_PORT localabstract:sndcpy
 "$ADB" $serial shell am start com.rom1v.sndcpy/.MainActivity
-echo "Press Enter once audio capture is authorized on the device to start playing..."
-read dummy
+string='com.rom1v.sndcpy/com.rom1v.sndcpy.MainActivity/android.view.ViewRootImpl'
+while true; do
+    if "$ADB" shell dumpsys gfxinfo com.rom1v.sndcpy | grep -q $string; then
+        break
+    fi
+done
+while true; do
+    if "$ADB" shell dumpsys gfxinfo com.rom1v.sndcpy | grep -q $string; then
+    	echo "waiting"
+    else
+    	break
+    fi
+done
 "$VLC" -Idummy --demux rawaud --network-caching=0 --play-and-exit tcp://localhost:"$SNDCPY_PORT"


### PR DESCRIPTION
Just two simple loop to check if sndcpy MainActivity is started and then ended, to automate the startup process.
This doesn't require user intervention so now sndcpy can be used without showing any terminal.

It uses [dumpsys](https://developer.android.com/studio/command-line/dumpsys) so it should be pretty standard.

I can't edit the .bat file right now so this only works on the linux version, if someone could write the code for the windows .bat file i'll appreciate it, otherwise i'll do it but it may not be very soon.