### PR TITLE
Fix immutable flag not found on android 12

### DIFF
--- a/app/src/main/java/com/rom1v/sndcpy/RecordService.java
+++ b/app/src/main/java/com/rom1v/sndcpy/RecordService.java
@@ -115,7 +115,7 @@ public class RecordService extends Service {
 
     private Notification.Action createStopAction() {
         Intent stopIntent = createStopIntent();
-        PendingIntent stopPendingIntent = PendingIntent.getService(this, 0, stopIntent, PendingIntent.FLAG_ONE_SHOT);
+        PendingIntent stopPendingIntent = PendingIntent.getService(this, 0, stopIntent, PendingIntent.FLAG_IMMUTABLE);
         Icon stopIcon = Icon.createWithResource(this, R.drawable.ic_close_24dp);
         String stopString = getString(R.string.action_stop);
         Notification.Action.Builder actionBuilder = new Notification.Action.Builder(stopIcon, stopString, stopPendingIntent);


### PR DESCRIPTION
Changed PendingIntent flag to IMMUTABLE as it is required in android 12.

Tested and working as intended on android 10 and android 12 device.