### PR TITLE
Fix "failed to stat sndcpy.apk"

### DIFF
--- a/sndcpy.bat
+++ b/sndcpy.bat
@@ -1,4 +1,6 @@
 @echo off
+cd /d "%~dp0"
+
 if not defined ADB set ADB=adb
 if not defined VLC set VLC="C:\Program Files\VideoLAN\VLC\vlc.exe"
 if not defined SNDCPY_APK set SNDCPY_APK=sndcpy.apk


### PR DESCRIPTION
When the batch file is ran outside of the folder which it is in, it show this error because sndcpy.apk is a relative path to the current folder. This PR makes it such that it changes the directory to the directory of sndcpy.bat such that the sndcpy.apk is always available no matter from where it has been ran.