### PR TITLE
Fix "sndcpy.apk no such file or directory" when executed globally

### DIFF
--- a/sndcpy.bat
+++ b/sndcpy.bat
@@ -1,7 +1,7 @@
 @echo off
 if not defined ADB set ADB=adb
 if not defined VLC set VLC="C:\Program Files\VideoLAN\VLC\vlc.exe"
-if not defined SNDCPY_APK set SNDCPY_APK=sndcpy.apk
+if not defined SNDCPY_APK set SNDCPY_APK=%~dp0\sndcpy.apk
 if not defined SNDCPY_PORT set SNDCPY_PORT=28200
 
 if not "%1"=="" (


### PR DESCRIPTION
Make `sndcpy.apk` relative to the script path, to enable running `sndcpy.bat` from outside the script directory or as a global script.


## Before:
![apk_not_found](https://github.com/rom1v/sndcpy/assets/52869398/812ee654-1856-44bb-bfa7-6f591084c38e)

## After:
![apk_found](https://github.com/rom1v/sndcpy/assets/52869398/dbc2bf64-a12b-4e76-9f22-ea00e09b6ea2)